### PR TITLE
Parser error display

### DIFF
--- a/app/Compiler.hs
+++ b/app/Compiler.hs
@@ -3,7 +3,7 @@
 
 module Compiler (compiler) where
 
-import Parser.ParseAndLex (parseAndLex)
+import Parser.ParseAndLex (parseAndLexFile)
 import Parser (pProgram)
 import GldsBytecode (writeProgramToFile)
 import ConvertASTtoInstructions (convertToStackInstructions)
@@ -12,14 +12,14 @@ import qualified Data.Text.IO as T.IO
 import StackMachine(StackProgram)
 import Helpers((>&<), orelse, headOr, orExitWith, exitWithErrorMessage)
 
-compileFile :: T.Text -> Either String StackProgram
-compileFile input = do
-    ast <- parseAndLex pProgram input >&< show
+compileFile :: FilePath -> T.Text -> Either String StackProgram
+compileFile filename input = do
+    ast <- parseAndLexFile filename pProgram input >&< show
     convertToStackInstructions ast
 
 compiler :: [String] -> IO ()
 compiler args = do
     file <- headOr args `orExitWith` "No input file to compile"
     contents <- T.IO.readFile file
-    instrs <- compileFile contents `orelse` exitWithErrorMessage
+    instrs <- compileFile file contents `orelse` exitWithErrorMessage
     writeProgramToFile "a.out" instrs

--- a/src/AlexToParsec.hs
+++ b/src/AlexToParsec.hs
@@ -6,7 +6,7 @@ module AlexToParsec (
 ) where
 
 import Parser.WithPos(WithPos (tokenVal, tokenLength, endPos, startPos))
-import Lexer.Tokens (Token(..), ControlSequence (LineBreak, Semicolon))
+import Lexer.Tokens (Token(..), ControlSequence (..), Literal (..), Keyword(..))
 import Data.Text (Text)
 import Text.Megaparsec (PosState(..))
 import Data.Proxy (Proxy(..))
@@ -100,7 +100,51 @@ instance MP.TraversableStream TokenStream where
 pxy :: Proxy TokenStream
 pxy = Proxy
 
+-- Custom token display functions
+
 showMyToken :: Token -> String
-showMyToken (Control LineBreak) = "linebreak"
-showMyToken (Control Semicolon) = "';'"
-showMyToken t = show t-- TODO: replace this by some pretty-print of tokens
+showMyToken (Keyword kw) = "keyword '" ++ showKeyword kw ++ "'"
+showMyToken (Literal lit) = "literal '" ++ showLiteral lit ++ "'"
+showMyToken (Identifier iden) = "identifier '" ++ show iden ++ "'"
+showMyToken (Control c) = showControl c
+
+showLiteral :: Literal -> String
+showLiteral (IntLiteral x) = show x
+
+showKeyword :: Keyword -> String
+showKeyword KeyWReturn = "return"
+showKeyword KeyWIf = "if"
+showKeyword KeyWUnless = "unless"
+showKeyword KeyWElse = "else"
+showKeyword KeyWWhile = "while"
+showKeyword KeyWUntil = "until"
+showKeyword KeyWDo = "do"
+showKeyword KeyWFun = "fun"
+showKeyword KeyWTrue = "true"
+showKeyword KeyWFalse = "false"
+showKeyword KeyWMain = "main"
+
+showControl :: ControlSequence -> String
+showControl LineBreak = "linebreak"
+showControl Semicolon = ";"
+showControl Colon = ":"
+showControl Comma = ","
+showControl OpenParen = "("
+showControl CloseParen = ")"
+showControl OpenBrace = "{"
+showControl CloseBrace = "}"
+showControl OperAssign = "="
+showControl OperAdd = "+"
+showControl OperSub = "-"
+showControl OperMul = "*"
+showControl OperDiv = "/"
+showControl OperMod = "%"
+showControl OperEquals = "=="
+showControl OperDiffer = "!="
+showControl OperNot = "!"
+showControl OperAnd = "&&"
+showControl OperOr = "||"
+showControl OperGt = ">"
+showControl OperLt = "<"
+showControl OperGe = ">="
+showControl OperLe = "<="

--- a/src/Lexer.x
+++ b/src/Lexer.x
@@ -91,6 +91,7 @@ tokens :-
 -- Each right-hand side has type :: AlexPosn -> Text -> WithPos Token
 type Lexer = (AlexPosn -> Text -> WithPos Token)
 data LexerError = LexerError FilePath AlexInput
+  deriving (Show, Eq)
 
 -- Some action helpers:
 tok :: (Text -> Token) -> Lexer

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -296,12 +296,12 @@ pAssignStatement = try (StAssignment
     )
 
 pStatement :: Parser Statement
-pStatement = choice $ map (<* pEndOfStatement)
+pStatement = choice (map (<* pEndOfStatement)
     [ pReturnStatement
     , pVariableDeclStatement
     , pAssignStatement
     , pExpression <&> StExpression
-    ]
+    ]) <?> "statement"
 
 pEndOfStatement :: Parser [Token]
 pEndOfStatement = do
@@ -339,6 +339,7 @@ pFunction = do
     body <- pBlockExpression <* manyEol <?> "function body"
 
     return $ Function name paramList retType body
+    <?> "function declaration"
 
 pMainFunction :: Parser MainFunction
 pMainFunction = do
@@ -347,11 +348,12 @@ pMainFunction = do
     body <- pBlockExpression <* manyEol
 
     return $ MainFunction paramList body
+    <?> "main function"
 
 pProgram :: Parser Program
 pProgram = do
-    preMain <- many pFunction
+    preMain <- hidden $ many pFunction
     mainFunc <- pMainFunction
-    postMain <- many pFunction
+    postMain <- hidden $ many pFunction
 
     return $ Program mainFunc (preMain ++ postMain)

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -283,7 +283,7 @@ pVariableDecl = try (VariableDeclaration
 pVariableDeclStatement :: Parser Statement
 pVariableDeclStatement = do
     decl <- pVariableDecl
-    value <- maybeParse (pControl OperAssign *> pExpression)
+    value <- maybeParse (pControl OperAssign *> manyEol *> pExpression)
     return $ StVariableDecl decl value
 
 pAssignStatement :: Parser Statement

--- a/src/Parser/ParseAndLex.hs
+++ b/src/Parser/ParseAndLex.hs
@@ -19,7 +19,7 @@ instance Show ParseLexError where
 
 parseAndLexFile :: FilePath -> Parser a -> Text -> Either ParseLexError a
 parseAndLexFile file parser input = do
-    tokens <- myScanTokens input >&< LexingError file
+    tokens <- myScanTokens file input >&< LexingError file
     let tokStream = TokenStream{ myStreamInput = input, unTokenStream = tokens}
 
     runParser parser file tokStream >&< ParsingError

--- a/src/Parser/ParseAndLex.hs
+++ b/src/Parser/ParseAndLex.hs
@@ -14,7 +14,7 @@ data ParseLexError = LexingError LexerError | ParsingError ParserError
 
 instance Show ParseLexError where
     show (LexingError err) = showLexError err
-    show (ParsingError err) = errorBundlePretty err
+    show (ParsingError err) = "parse error:\n" ++ errorBundlePretty err
 
 parseAndLex :: Parser a -> Text -> Either ParseLexError a
 parseAndLex parser input = do

--- a/src/Parser/ParseAndLex.hs
+++ b/src/Parser/ParseAndLex.hs
@@ -11,15 +11,15 @@ import Text.Megaparsec (runParser, errorBundlePretty)
 import AlexToParsec (TokenStream(TokenStream, myStreamInput, unTokenStream))
 import Helpers((>&<))
 
-data ParseLexError = LexingError LexerError | ParsingError ParserError
+data ParseLexError = LexingError FilePath LexerError | ParsingError ParserError
 
 instance Show ParseLexError where
-    show (LexingError err) = showLexError err
+    show (LexingError path err) = path ++ ": " ++ showLexError err
     show (ParsingError err) = "parse error:\n" ++ errorBundlePretty err
 
 parseAndLexFile :: FilePath -> Parser a -> Text -> Either ParseLexError a
 parseAndLexFile file parser input = do
-    tokens <- myScanTokens input >&< LexingError
+    tokens <- myScanTokens input >&< LexingError file
     let tokStream = TokenStream{ myStreamInput = input, unTokenStream = tokens}
 
     runParser parser file tokStream >&< ParsingError

--- a/src/Parser/ParseAndLex.hs
+++ b/src/Parser/ParseAndLex.hs
@@ -1,5 +1,6 @@
 module Parser.ParseAndLex (
     ParseLexError(..),
+    parseAndLexFile,
     parseAndLex,
 ) where
 
@@ -16,9 +17,12 @@ instance Show ParseLexError where
     show (LexingError err) = showLexError err
     show (ParsingError err) = "parse error:\n" ++ errorBundlePretty err
 
-parseAndLex :: Parser a -> Text -> Either ParseLexError a
-parseAndLex parser input = do
+parseAndLexFile :: FilePath -> Parser a -> Text -> Either ParseLexError a
+parseAndLexFile file parser input = do
     tokens <- myScanTokens input >&< LexingError
     let tokStream = TokenStream{ myStreamInput = input, unTokenStream = tokens}
 
-    runParser parser "" tokStream >&< ParsingError
+    runParser parser file tokStream >&< ParsingError
+
+parseAndLex :: Parser a -> Text -> Either ParseLexError a
+parseAndLex = parseAndLexFile ""

--- a/src/Parser/ParseAndLex.hs
+++ b/src/Parser/ParseAndLex.hs
@@ -11,15 +11,15 @@ import Text.Megaparsec (runParser, errorBundlePretty)
 import AlexToParsec (TokenStream(TokenStream, myStreamInput, unTokenStream))
 import Helpers((>&<))
 
-data ParseLexError = LexingError FilePath LexerError | ParsingError ParserError
+data ParseLexError = LexingError LexerError | ParsingError ParserError
 
 instance Show ParseLexError where
-    show (LexingError path err) = path ++ ": " ++ showLexError err
+    show (LexingError err) = showLexError err
     show (ParsingError err) = "parse error:\n" ++ errorBundlePretty err
 
 parseAndLexFile :: FilePath -> Parser a -> Text -> Either ParseLexError a
 parseAndLexFile file parser input = do
-    tokens <- myScanTokens file input >&< LexingError file
+    tokens <- myScanTokens file input >&< LexingError
     let tokStream = TokenStream{ myStreamInput = input, unTokenStream = tokens}
 
     runParser parser file tokStream >&< ParsingError

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -36,8 +36,10 @@ import Lexer.Tokens (
 import Parser.ParseAndLex (
     ParseLexError(..),
     parseAndLex,
-    parseAndLex
+    parseAndLex,
+    parseAndLexFile,
     )
+import Helpers ((>&<))
 import Parser.Shorthands
 import Parser.AST (BlockExpression(BlockExpression), Function (Function), MainFunction (MainFunction), Program (Program))
 import Test.Hspec.Megaparsec (etok, err, utok, shouldFailWith, elabel)
@@ -419,3 +421,16 @@ spec = do
                 , fn "otherfunc" [vdecl "bool" "a"] Nothing []
                 , fn "lastfunc" [] Nothing []
                 ]
+        it "parseProgram error" $ do
+            let res = parseAndLexFile "file.cl" pProgram
+                    "fun a {\n    my_func(1, 2\n}"
+            let e = res >&< show
+            e `shouldBe` Left "\
+            \parse error:\n\
+            \file.cl:2:17:\n\
+            \  |\n\
+            \2 |     my_func(1, 2\n\
+            \  |                 ^\n\
+            \unexpected linebreak\n\
+            \expecting ) or ,\n\
+            \"


### PR DESCRIPTION
This PR slightly improves parser error messages in a few ways:

- Improve parser error display of tokens
- Add prefix "parse error:" to display of parse errors
- Make compiler report filename in parsing errors
- Reformat lexer error messages
- Make compiler report filename in lexer errors
