### PR TITLE
Run module

### DIFF
--- a/GLaDOS.cabal
+++ b/GLaDOS.cabal
@@ -67,6 +67,7 @@ executable GLaDOS
   main-is: Main-all.hs
   other-modules:
       Compiler
+      Run
       VM
       Paths_GLaDOS
   autogen-modules:
@@ -95,6 +96,7 @@ executable GLaDOS-cmp
   main-is: Main-cmp.hs
   other-modules:
       Compiler
+      Run
       VM
       Paths_GLaDOS
   autogen-modules:
@@ -123,6 +125,7 @@ executable GLaDOS-exe
   main-is: Main-exe.hs
   other-modules:
       Compiler
+      Run
       VM
       Paths_GLaDOS
   autogen-modules:

--- a/app/Compiler.hs
+++ b/app/Compiler.hs
@@ -1,7 +1,7 @@
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Compiler (compiler) where
+module Compiler (compiler, compileFile) where
 
 import Parser.ParseAndLex (parseAndLexFile)
 import Parser (pProgram)

--- a/app/Main-all.hs
+++ b/app/Main-all.hs
@@ -4,6 +4,7 @@ import System.Environment(getArgs)
 import VM(vm, disassembler)
 import Compiler(compiler)
 import System.Exit (exitWith, ExitCode (ExitFailure))
+import Run (run)
 
 type Module = (String, ([String] -> IO (), String))
 
@@ -11,6 +12,7 @@ modules :: [Module]
 modules =
     [ ("build",       (compiler,     "Produce an executable from source files"))
     , ("exec",        (vm,           "Execute a previously built executable"))
+    , ("run",         (run,          "Compile and execute without producing an object file"))
     , ("disassemble", (disassembler, "Disassemble one or more executables"))
     ]
 

--- a/app/Run.hs
+++ b/app/Run.hs
@@ -11,9 +11,9 @@ runHelpMessage  = "Usage: run {filename | -}\n\n"
                 ++ "Run a FunChill program directly from source code\n"
                 ++ "Input can be a file, or stdin with \"-\" as filename\n"
 
-runFromContent :: Text -> IO ()
-runFromContent contents = do
-    program <- compileFile contents `orelse` exitWithErrorMessage
+runFromContent :: FilePath -> Text -> IO ()
+runFromContent filename contents = do
+    program <- compileFile filename contents `orelse` exitWithErrorMessage
     result <- execute' program `orelse` exitWithErrorMessage
     print result
 
@@ -22,8 +22,8 @@ run ["--help"] = putStrLn runHelpMessage >> exitSuccess
 run ["-h"] = run ["--help"]
 run ["-"] = do
     contents <- T.IO.getContents
-    runFromContent contents
+    runFromContent "<stdin>" contents
 run [inputFile] = do
     contents <- T.IO.readFile inputFile
-    runFromContent contents
+    runFromContent inputFile contents
 run _ = exitWithErrorMessage runHelpMessage

--- a/app/Run.hs
+++ b/app/Run.hs
@@ -1,0 +1,14 @@
+module Run (run) where
+import Helpers (exitWithErrorMessage, orelse)
+import qualified Data.Text.IO as T.IO
+import Compiler (compileFile)
+import StackMachine (execute')
+
+
+run :: [String] -> IO ()
+run [inputFile] = do
+    contents <- T.IO.readFile inputFile
+    program <- compileFile contents `orelse` exitWithErrorMessage
+    result <- execute' program `orelse` exitWithErrorMessage
+    print result
+run _ = exitWithErrorMessage "Expecting a single file to run"

--- a/app/Run.hs
+++ b/app/Run.hs
@@ -1,14 +1,29 @@
 module Run (run) where
 import Helpers (exitWithErrorMessage, orelse)
+import Data.Text(Text)
 import qualified Data.Text.IO as T.IO
 import Compiler (compileFile)
 import StackMachine (execute')
+import System.Exit (exitSuccess)
 
+runHelpMessage :: String
+runHelpMessage  = "Usage: run {filename | -}\n\n"
+                ++ "Run a FunChill program directly from source code\n"
+                ++ "Input can be a file, or stdin with \"-\" as filename\n"
 
-run :: [String] -> IO ()
-run [inputFile] = do
-    contents <- T.IO.readFile inputFile
+runFromContent :: Text -> IO ()
+runFromContent contents = do
     program <- compileFile contents `orelse` exitWithErrorMessage
     result <- execute' program `orelse` exitWithErrorMessage
     print result
-run _ = exitWithErrorMessage "Expecting a single file to run"
+
+run :: [String] -> IO ()
+run ["--help"] = putStrLn runHelpMessage >> exitSuccess
+run ["-h"] = run ["--help"]
+run ["-"] = do
+    contents <- T.IO.getContents
+    runFromContent contents
+run [inputFile] = do
+    contents <- T.IO.readFile inputFile
+    runFromContent contents
+run _ = exitWithErrorMessage runHelpMessage

--- a/src/StackMachine.hs
+++ b/src/StackMachine.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-{-# OPTIONS_GHC -DDEBUG #-} -- Uncomment to activate tracing
+-- {-# OPTIONS_GHC -DDEBUG #-} -- Uncomment to activate tracing
 
 module StackMachine (
     Value(..),


### PR DESCRIPTION
This quick PR adds a `run` module (subcommand to the combined main) which allows compiling and executing without producing an intermediate object file.

```
$ ./glados --help
FunChill combined toolkit

Available commands are:
- build:        Produce an executable from source files
- exec:         Execute a previously built executable
- run:          Compile and execute without producing an object file
- disassemble:  Disassemble one or more executables


$ ./glados run --help
Usage: run {filename | -}

Run a FunChill program directly from source code
Input can be a file, or stdin with "-" as filename
```
